### PR TITLE
chaos db upgrade should be disabled by default

### DIFF
--- a/src/chaos/values.yaml
+++ b/src/chaos/values.yaml
@@ -48,7 +48,7 @@ chaos-manager:
 
   jobs:
     chaos_db_upgrade:
-      enabled: 'false'
+      enabled: false
       slackURLToNotify: 'no-url'
       image:
         registry: docker.io


### PR DESCRIPTION
Signed-off-by: Sagar Kumar <sagar.kumar@harness.io>